### PR TITLE
added: Barebones tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,27 @@
+load('ext://namespace', 'namespace_create', 'namespace_inject')
+
+development_namespace='cronus'
+
+namespace_create(development_namespace)
+
+# There is almost certainly a way of just listing these files
+# or using the kustomization file, but I'm being crude
+k8s_yaml([
+  'manifests/cronjob.yaml',
+  'manifests/deployment.yaml',
+  'manifests/kubectl-deployment.yaml',
+  'manifests/role.yaml',
+  'manifests/rolebinding.yaml',
+  'manifests/service.yaml',
+  'manifests/serviceaccount.yaml',
+])
+
+
+# Build: tell Tilt what images to build from which directories
+
+docker_build('nickkeers/cronus', '.')
+
+# Watch: tell Tilt how to connect locally/categorise things
+
+k8s_resource('cronus', labels=["app"])
+k8s_resource('hello', labels=["cronjobs"])


### PR DESCRIPTION
This is more of an example of what one might look like

To use, install tilt from https://tilt.dev/, then run `tilt up` in the root