### PR TITLE
Format times in table view as relative formats

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -29,8 +29,27 @@ func NewCronusAPI(manager *cronus.CronJobManager) *CronusAPI {
 	return api
 }
 
+// readableDateTime is modified to convert absolute times to relative formats.
 func readableDateTime(t time.Time) string {
-	return t.Format("2006-01-02 15:04:05")
+	now := time.Now()
+	diff := now.Sub(t)
+
+	switch {
+	case diff < time.Minute:
+		return "just now"
+	case diff < time.Hour:
+		return fmt.Sprintf("%d minutes ago", diff/time.Minute)
+	case diff < 24*time.Hour:
+		return fmt.Sprintf("%d hours ago", diff/time.Hour)
+	case diff < 7*24*time.Hour:
+		return fmt.Sprintf("%d days ago", diff/(24*time.Hour))
+	case diff < 30*24*time.Hour:
+		return fmt.Sprintf("%d weeks ago", diff/(7*24*time.Hour))
+	case diff < 365*24*time.Hour:
+		return fmt.Sprintf("%d months ago", diff/(30*24*time.Hour))
+	default:
+		return fmt.Sprintf("%d years ago", diff/(365*24*time.Hour))
+	}
 }
 
 func (c *CronusAPI) setupRoutes() {


### PR DESCRIPTION
Related to #6

Updates the `readableDateTime` function in `internal/routes/routes.go` to display times in a human-readable, relative format.

- Modifies the `readableDateTime` function to calculate the difference between the current time and the provided time, then formats this difference as a relative time string such as "just now", "x minutes ago", "x hours ago", "x days ago", "x weeks ago", "x months ago", or "x years ago".
- Implements a switch case to handle different time ranges, ensuring that the displayed time is both accurate and easily understandable for users.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nickkeers/cronus/issues/6?shareId=11784445-3cb2-47dd-bc8e-767c299269b6).